### PR TITLE
1.0.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 #### Spectre.css Changelog
 
+##### v1.0.0-alpha-1
+
+- New background class colors `.bg-color-dark` and `.bg-color-light`. [fb1224c]
+- Fix variable name from `$lighten` to `$lightness` in `textarea.form-input`. [54790ae]
+- Update missing `color()` function in styles and use prettier on files. [aed7fe0]
+- Fix includes mixin `bg-color-variant()` by adding missing sass variables. [ebd492c]
+- Update sass variable name to css style and add `!important` to `text-color-variant` mixin. [03713ee]
+
+[fb1224c]: https://github.com/angular-package/spectre.css/commit/fb1224c6799f0d6abdf992396e09b6d547f27e75
+[95648b3]: https://github.com/angular-package/spectre.css/commit/95648b379eb18437dbd15bd07ce6d6daf0c5c3fa
+[54790ae]: https://github.com/angular-package/spectre.css/commit/54790aef0bdf578d7aa2e6aeb01f1da905a00189
+[aed7fe0]: https://github.com/angular-package/spectre.css/commit/aed7fe0be311f9101a9c92767d244a2caca24d82
+[ebd492c]: https://github.com/angular-package/spectre.css/commit/ebd492c0cc835cde005e3fac371404461bec1b77
+[03713ee]: https://github.com/angular-package/spectre.css/commit/03713ee038121d9b8a14c346c1dc08f4cf80f35a
+
 ##### v1.0.0-alpha
 
 - Add helpers. [a3fac35]
@@ -18,7 +33,7 @@
 [b8dd9c4]: https://github.com/angular-package/spectre.css/commit/b8dd9c414c378ee49fa7e2d3823f7da88b9cb0e1
 [a89d3f7]: https://github.com/angular-package/spectre.css/commit/a89d3f7eed3913f71096bb0c0443ee66a736d9ac
 [978a9ba]: https://github.com/angular-package/spectre.css/commit/978a9baa33c6557d0c493c9768d1c4899d057ac9
-[759feb]: https://github.com/angular-package/spectre.css/commit/759feb7fc7ad180f8b0aa325b4b87c056a904adb
+[759feb7]: https://github.com/angular-package/spectre.css/commit/759feb7fc7ad180f8b0aa325b4b87c056a904adb
 
 [4ead2ca]: https://github.com/angular-package/spectre.css/commit/4ead2caea86e6fbbb7ce7818f38df01e71e803b8
 [5aebf31]: https://github.com/angular-package/spectre.css/commit/5aebf31192dbec68c727b834b643dd0e98a5aaec
@@ -28,7 +43,6 @@
 
 [6ad8904]: https://github.com/angular-package/spectre.css/commit/6ad89043b1b172697bdbb0d33a10a8b9e7f332b0
 [4110d67]: https://github.com/angular-package/spectre.css/commit/4110d67227cb05e1c43b30a98cc8385f5a821b85
-
 
 ##### v0.5.10 [#](https://github.com/angular-package/spectre.css/releases/tag/v0.5.10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,20 @@
 #### Spectre.css Changelog
 
-##### v1.0.0-alpha-1
+##### v1.0.0-alpha.1
 
+- Change file name from general `function/_css-variable-color.scss` to just `functions/_color.scss`. [a8b14ac]
+- Move mixins from `mixins/_css-variable-color.scss` to separate files `_define-color.scss` and `_define-color-based-on.scss`. [e9bb18b]
+- Change folder name from `function` to `functions` for Spectre.css naming consistency. [4582370]
+- Change `.bg-gray` to use `$bg-gray` SCSS variable instead of `$bg-color`. [ebd492c]
+- Fix includes mixin `bg-color-variant()` by adding missing sass variables. [ebd492c]
 - New background class colors `.bg-color-dark` and `.bg-color-light`. [fb1224c]
 - Fix variable name from `$lighten` to `$lightness` in `textarea.form-input`. [54790ae]
 - Update missing `color()` function in styles and use prettier on files. [aed7fe0]
-- Fix includes mixin `bg-color-variant()` by adding missing sass variables. [ebd492c]
 - Update sass variable name to css style and add `!important` to `text-color-variant` mixin. [03713ee]
 
+[a8b14ac]: https://github.com/angular-package/spectre.css/commit/a8b14acd49be4e82eb387dfde0b964e7a41bd664
+[e9bb18b]: https://github.com/angular-package/spectre.css/commit/e9bb18b9ac4c47b40368f2d8a09e82476e08390b
+[4582370]: https://github.com/angular-package/spectre.css/commit/4582370757b32c2af3e2e138974485e7f35144de
 [fb1224c]: https://github.com/angular-package/spectre.css/commit/fb1224c6799f0d6abdf992396e09b6d547f27e75
 [95648b3]: https://github.com/angular-package/spectre.css/commit/95648b379eb18437dbd15bd07ce6d6daf0c5c3fa
 [54790ae]: https://github.com/angular-package/spectre.css/commit/54790aef0bdf578d7aa2e6aeb01f1da905a00189

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # angular-package
 
-<img align="right"  width="92" height="92" src="https://avatars.githubusercontent.com/u/31412194?s=400&u=c9929aa36826318ccac8f7b84516e1ce3af7e21c&v=4" />
+<a href='https://angular-package.dev' target='_blank'>
+  <img align="right"  width="92" height="92" src="https://avatars.githubusercontent.com/u/31412194?s=400&u=c9929aa36826318ccac8f7b84516e1ce3af7e21c&v=4" />
+</a>
 
 The angular-package supports the development process of [angular](https://angular.io)-based applications in varied ways through the thoughtful, reusable, easy-to-use small pieces of code called packages.
-
-[**angular-package.dev**](https://angular-package.dev) | [**docs.angular-package.dev**](https://docs.angular-package.dev)
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -43,14 +43,27 @@ There are 2 ways to get started with Spectre CSS framework in your projects. You
 
 ## Demonstration
 
-Demonstration will be available soon here http://angular-package.dev/ui-kit/component/theme
+Demonstration will be available soon here https://angular-package.dev/ui-kit/component/theme
 
 ## Usage
 
 ```scss
-@import 'node_modules/@angular-package/spectre.css/spectre.scss';
-@import 'node_modules/@angular-package/spectre.css/spectre-exp.scss';
-@import 'node_modules/@angular-package/spectre.css/spectre-icons.scss';
+// Main spectre.
+@use 'node_modules/@angular-package/spectre.css/spectre' as *;
+@use 'node_modules/@angular-package/spectre.css/spectre-exp' as *;
+@use 'node_modules/@angular-package/spectre.css/spectre-icons' as *;
+
+// Define variables.
+@use 'node_modules/@angular-package/spectre.css/css-variables' as *;
+
+// Get functions.
+@use 'node_modules/@angular-package/spectre.css/functions' as *;
+
+// Get mixins.
+@use 'node_modules/@angular-package/spectre.css/mixins' as *;
+
+// Get variables.
+@use 'node_modules/@angular-package/spectre.css/variables' as *;
 ```
 
 ## SCSS Variables
@@ -58,18 +71,18 @@ Demonstration will be available soon here http://angular-package.dev/ui-kit/comp
 Colors with a specific **hex** on which others are based.
 
 ```scss
-// _variables.scss
+// src/_variables.scss
 // Core colors
-$primary-color: #5755d9 !default;
 $accent-color: #9932CC !default; // New.
 $dark-color: #303742 !default;
 $light-color: #fff !default;
+$primary-color: #5755d9 !default;
 
 // Control colors
+$error-color: #e85600 !default;
 $info-color: #d9edf7 !default; // New.
 $success-color: #32b643 !default;
 $warning-color: #ffb700 !default;
-$error-color: #e85600 !default;
 
 // Other colors
 $code-color: #d73e48 !default;
@@ -119,8 +132,8 @@ The `color-scheme` variable is set to `normal`.
 Each **hex** color has **four** CSS variables defined by the mixin `define-color($name, $color)`, split into hsl form, where suffix `h` indicates `hue`, `l` lightness, `s` saturation and `a` - alpha.
 
 ```scss
-// mixins/_css-variable-color.scss
-// Define color.
+// src/mixins/_define-color.scss
+// Defines CSS variable color in hsl form.
 @mixin define-color($name, $color) {
   --s-#{$name}-h: #{hue($color)};
   --s-#{$name}-l: #{lightness($color)};
@@ -132,17 +145,16 @@ Each **hex** color has **four** CSS variables defined by the mixin `define-color
 For example `primary-color` is built from the CSS variables.
 
 ```css
-  --s-primary-color-h: 240.9090909091deg; // Hue.
-  --s-primary-color-l: 59.2156862745%; // Lightness.
-  --s-primary-color-s: 63.4615384615%; // Saturation.
-  --s-primary-color-a: 1; // Alpha.
+--s-primary-color-h: 240.9090909091deg; // Hue.
+--s-primary-color-l: 59.2156862745%; // Lightness.
+--s-primary-color-s: 63.4615384615%; // Saturation.
+--s-primary-color-a: 1; // Alpha.
 ```
 
-CSS variables are defined in the `:root` and `:host`.
+CSS variables are defined in both `:root` and `:host`.
 
 ```scss
-// _css-variables.scss
-
+// src/_css-variables.scss
 :root, :host {
   // Core colors.
   @include define-color('primary-color', $primary-color); // #5755d9
@@ -165,7 +177,7 @@ CSS variables are defined in the `:root` and `:host`.
 Each color that is based on **hex** color has **four** CSS variables defined by the mixin `define-color-based-on($name, $color, $lightness: 0%)`, split into hsl form, where suffix `h` indicates `hue`, `l` lightness, `s` saturation and `a` - alpha.
 
 ```scss
-// mixins/_css-variable-color.scss
+// src/mixins/_define-color-based-on.scss
 @mixin define-color-based-on($name, $color, $lightness: 0%) {
   --s-#{$name}-h: var(--s-#{$color}-h);
   --s-#{$name}-l: calc(var(--s-#{$color}-l) + #{$lightness});
@@ -177,16 +189,18 @@ Each color that is based on **hex** color has **four** CSS variables defined by 
 Color that based on `primary-color` for example `secondary-color` is built from the css variables:
 
 ```css
+:root, :host {
   --s-secondary-color-h: var(--s-primary-color-h);
   --s-secondary-color-l: calc(var(--s-primary-color-l) + 37.5%);
   --s-secondary-color-s: var(--s-primary-color-s);
   --s-secondary-color-a: var(--s-primary-color-a);
+}
 ```
 
-CSS variables that are based on others are also defined in the `:root` and `:host`.
+CSS variables that are based on others are also defined in both `:root` and `:host`.
 
 ```scss
-// _css-variables.scss
+// src/_css-variables.scss
 :root, :host {
   // Core colors.
   @include define-color-based-on('primary-color-dark', 'primary-color', $lightness: -3%); // darken($primary-color, 3%)
@@ -223,7 +237,7 @@ CSS variables that are based on others are also defined in the `:root` and `:hos
 Colors are read by the function `color($name, $hue: 0deg, $lightness: 0%, $saturation: 0%, $alpha: 1)`.
 
 ```scss
-// function/_css-variable-color.scss
+// src/functions/_color.scss
 // Color variable.
 @function color($name, $hue: 0deg, $lightness: 0%, $saturation: 0%, $alpha: 1) {
   @return hsla(
@@ -238,7 +252,7 @@ Colors are read by the function `color($name, $hue: 0deg, $lightness: 0%, $satur
 For example `primary-color` or `primary-color-dark`:
 
 ```scss
-@use 'function/css-variable-color';
+@use 'node_modules/@angular-package/spectre.css/functions' as *;
 
 .primary-color {
   background: color('primary-color');

--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@
 
 The angular-package supports the development process of [angular](https://angular.io)-based applications in varied ways through the thoughtful, reusable, easy-to-use small pieces of code called packages.
 
-[**docs.angular-package.dev**](https://docs.angular-package.dev)
+[**angular-package.dev**](https://angular-package.dev) | [**docs.angular-package.dev**](https://docs.angular-package.dev)
 
 <br>
+
+---
+
 <br>
 
 <a href="https://picturepan2.github.io/spectre">
@@ -15,9 +18,9 @@ The angular-package supports the development process of [angular](https://angula
 
 ## Spectre.css
 
-**This Spectre.css is maintained by the angular-package.**
-
 [![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)
+
+**This Spectre.css is maintained by the `@angular-package`.**
 
 Spectre.css is a lightweight, responsive and modern CSS framework.
 
@@ -170,7 +173,7 @@ CSS variables are defined in both `:root` and `:host`.
 
   // Other colors
   @include define-color('code-color', $code-color); // #d73e48
-  @include define-color('highlight-color', $highlight-color); // #ffe9b3
+  @include define-color('highlight-color', $highlight-color); // #ffe9b3  
 }
 ```
 
@@ -261,6 +264,48 @@ For example `primary-color` or `primary-color-dark`:
 .primary-color-dark {
   background: color('primary-color-dark');
 }
+```
+
+## Background colors
+
+In the original Spectre.css, background colors are based on SCSS variables, but in `@angular-package` Spectre.css they are based on CSS variables.
+They are also set the same way, by the `bg-color-variant()` mixin, but using respective SCSS variables to change the lightness of the background font color.
+In the future version, the lightness of the text color will depend on the CSS variable.
+
+Original Spectre.css backgrounds are using the same SCSS variable name as the class name except one `.bg-gray`, which uses `$bg-color`.
+This version, `$bg-color` SASS variable is used in the new background `.bg` class, and `.bg-gray` uses `$gray-color` to have consistent naming.
+
+There are also new background `.bg-accent` (`$accent-color`), `.bg-gray-dark` (`$gray-color-dark`), `.bg-gray-light` (`$gray-color-light`), `.bg-info` (`$info-color`) classes that are consistent in Spectre.css naming convention, but
+they are also `.bg-color-dark` (`$bg-color-dark`), `.bg-color-light` (`$bg-color-light`) that aren't.
+
+```scss
+/*
+  Background colors
+*/
+// BG core colors
+@include bg-color-variant('.bg', 'bg-color', $bg-color); // ! New color, it's an old .bg-gray
+@include bg-color-variant('.bg-accent', 'accent-color', $accent-color); // ! New color.
+@include bg-color-variant('.bg-dark', 'dark-color', $dark-color);
+@include bg-color-variant('.bg-color-dark', 'bg-color-dark', $bg-color-dark); // ! New color that uses $bg-color-dark
+@include bg-color-variant('.bg-light', 'light-color', $light-color);
+@include bg-color-variant('.bg-color-light', 'bg-color-light', $bg-color-light); // ! New color that uses $bg-color-light
+@include bg-color-variant('.bg-primary', 'primary-color', $primary-color);
+@include bg-color-variant('.bg-secondary', 'secondary-color', $secondary-color);
+
+/*
+  Control colors.
+*/
+@include bg-color-variant('.bg-error', 'error-color', $error-color);
+@include bg-color-variant('.bg-info', 'info-color', $info-color); // ! New color.
+@include bg-color-variant('.bg-success', 'success-color', $success-color);
+@include bg-color-variant('.bg-warning', 'warning-color', $warning-color);
+
+/*
+  Gray colors.
+*/
+@include bg-color-variant('.bg-gray', 'gray-color', $gray-color); // ? .bg-gray is not $bg-color but directly $gray-color.
+@include bg-color-variant('.bg-gray-dark', 'gray-color-dark', $gray-color-dark); // ! New color.
+@include bg-color-variant('.bg-gray-light', 'gray-color-light', $gray-color-light); // ! New color.
 ```
 
 ## Helper class
@@ -356,7 +401,7 @@ with the CSS variable result:
 
 ### Layout
 
-- [Flexbox grid](https://picturepan2.github.io/spectre/layout/grid.html) 
+- [Flexbox grid](https://picturepan2.github.io/spectre/layout/grid.html)
 - [Responsive](https://picturepan2.github.io/spectre/layout/responsive.html)
 - [Hero](https://picturepan2.github.io/spectre/layout/hero.html)
 - [Navbar](https://picturepan2.github.io/spectre/layout/navbar.html)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,10 @@
 # angular-package
 
-<img align="left"  width="92" height="92" src="https://avatars.githubusercontent.com/u/31412194?s=400&u=c9929aa36826318ccac8f7b84516e1ce3af7e21c&v=4" />
+<img align="right"  width="92" height="92" src="https://avatars.githubusercontent.com/u/31412194?s=400&u=c9929aa36826318ccac8f7b84516e1ce3af7e21c&v=4" />
 
 The angular-package supports the development process of [angular](https://angular.io)-based applications in varied ways through the thoughtful, reusable, easy-to-use small pieces of code called packages.
 
 [**angular-package.dev**](https://angular-package.dev) | [**docs.angular-package.dev**](https://docs.angular-package.dev)
-
-<br>
-
----
 
 <br>
 

--- a/css-variables.scss
+++ b/css-variables.scss
@@ -1,0 +1,1 @@
+@forward 'src/css-variables';

--- a/functions.scss
+++ b/functions.scss
@@ -1,0 +1,1 @@
+@forward 'src/functions';

--- a/mixins.scss
+++ b/mixins.scss
@@ -1,0 +1,1 @@
+@forward 'src/mixins';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular-package/spectre.css",
-  "version": "1.0.0-alpha",
+  "version": "1.0.0-alpha.1",
   "homepage": "http://picturepan2.github.io/spectre",
   "author": "Yan Zhu <picturepan2@hotmail.com>",
   "description": "Spectre.css: A lightweight, responsive and modern CSS framework",

--- a/spectre-exp.scss
+++ b/spectre-exp.scss
@@ -1,6 +1,6 @@
 // Variables and mixins
-@forward 'src/variables';
-@forward 'src/mixins';
+// @forward 'src/mixins';
+// @forward 'src/variables';
 @use 'src/variables' as *;
 
 /*! Spectre.css Experimentals v#{$version} | MIT License | github.com/picturepan2/spectre */

--- a/spectre-icons.scss
+++ b/spectre-icons.scss
@@ -1,6 +1,6 @@
 // Variables and mixins
-@forward 'src/variables';
-@forward 'src/mixins';
+// @forward 'src/mixins';
+// @forward 'src/variables';
 @use 'src/variables' as *;
 
 /*! Spectre.css Icons v#{$version} | MIT License | github.com/picturepan2/spectre */

--- a/spectre.scss
+++ b/spectre.scss
@@ -1,8 +1,9 @@
 // Variables and mixins
-@forward 'src/variables';
-@forward 'src/mixins';
-@forward 'src/css-variables';
-@use 'src/variables' as *;
+@forward 'mixins';
+@forward 'functions';
+@forward 'css-variables';
+@forward 'variables';
+@use 'variables' as *;
 
 /*! Spectre.css v#{$version} | MIT License | github.com/picturepan2/spectre */
 // Reset and dependencies

--- a/src/_accordions.scss
+++ b/src/_accordions.scss
@@ -20,7 +20,7 @@
     padding: $unit-1 $unit-2;
 
     .icon {
-      transition: transform .25s;
+      transition: transform 0.25s;
     }
   }
 
@@ -28,7 +28,7 @@
     margin-bottom: $layout-spacing;
     max-height: 0;
     overflow: hidden;
-    transition: max-height .25s;
+    transition: max-height 0.25s;
   }
 }
 

--- a/src/_asian.scss
+++ b/src/_asian.scss
@@ -40,6 +40,6 @@ html:lang(ko),
   s + s,
   u + ins,
   u + u {
-    margin-left: .125em;
+    margin-left: 0.125em;
   }
 }

--- a/src/_autocomplete.scss
+++ b/src/_autocomplete.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'mixins/shadow' as *;
 @use 'variables' as *;
 

--- a/src/_avatars.scss
+++ b/src/_avatars.scss
@@ -1,5 +1,5 @@
+@use 'functions' as *;
 @use 'mixins/avatar' as *;
-@use 'function/css-variable-color' as *;
 @use 'variables' as *;
 
 // Avatars
@@ -9,7 +9,7 @@
   background: color('primary-color');
   border-radius: 50%;
   // color: rgba($light-color, .85); // old spectre.css
-  color: color('light-color', $alpha: .85);
+  color: color('light-color', $alpha: 0.85);
   display: inline-block;
   font-weight: 300;
   line-height: 1.25;
@@ -58,8 +58,8 @@
     // box-shadow: 0 0 0 $border-width-lg $light-color; // old spectre.css
     box-shadow: 0 0 0 $border-width-lg color('light-color');
     border-radius: 50%;
-    height: .5em;
-    width: .5em;
+    height: 0.5em;
+    width: 0.5em;
 
     &.online {
       // background: $success-color; // old spectre.css

--- a/src/_badges.scss
+++ b/src/_badges.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'variables' as *;
 
 // Badges
@@ -12,29 +12,29 @@
       // background: $primary-color; // old spectre.css
       background: color('primary-color');
       background-clip: padding-box;
-      border-radius: .5rem;
+      border-radius: 0.5rem;
       // box-shadow: 0 0 0 .1rem $bg-color-light; // old spectre.css
-      box-shadow: 0 0 0 .1rem color('bg-color-light');
+      box-shadow: 0 0 0 0.1rem color('bg-color-light');
       // color: $light-color; // old spectre.css
       color: color('light-color');
       content: attr(data-badge);
       display: inline-block;
-      transform: translate(-.05rem, -.5rem);
+      transform: translate(-0.05rem, -0.5rem);
     }
   }
   &[data-badge] {
     &::after {
       font-size: $font-size-sm;
-      height: .9rem;
+      height: 0.9rem;
       line-height: 1;
-      min-width: .9rem;
-      padding: .1rem .2rem;
+      min-width: 0.9rem;
+      padding: 0.1rem 0.2rem;
       text-align: center;
       white-space: nowrap;
     }
   }
   &:not([data-badge]),
-  &[data-badge=""] {
+  &[data-badge=''] {
     &::after {
       height: 6px;
       min-width: 6px;

--- a/src/_bars.scss
+++ b/src/_bars.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'variables' as *;
 
 // Bars
@@ -74,7 +74,7 @@
 
     &:active {
       // box-shadow: 0 0 0 .1rem $primary-color; // old spectre.css
-      box-shadow: 0 0 0 .1rem color('primary-color');
+      box-shadow: 0 0 0 0.1rem color('primary-color');
     }
   }
 }

--- a/src/_base.scss
+++ b/src/_base.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'mixins/shadow' as *;
 @use 'variables' as *;
 

--- a/src/_breadcrumbs.scss
+++ b/src/_breadcrumbs.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'variables' as *;
 
 // Breadcrumbs
@@ -27,7 +27,7 @@
       &::before {
         // color: $gray-color-dark; // old spectre.css
         color: color('gray-color-dark');
-        content: "/";
+        content: '/';
         padding-right: $unit-2;
       }
     }

--- a/src/_buttons.scss
+++ b/src/_buttons.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'mixins/button' as *;
 @use 'mixins/shadow' as *;
 @use 'variables' as *;
@@ -22,7 +22,7 @@
   padding: $control-padding-y $control-padding-x;
   text-align: center;
   text-decoration: none;
-  transition: background .2s, border .2s, box-shadow .2s, color .2s;
+  transition: background 0.2s, border 0.2s, box-shadow 0.2s, color 0.2s;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -63,7 +63,7 @@
   &:disabled,
   &.disabled {
     cursor: default;
-    opacity: .5;
+    opacity: 0.5;
     pointer-events: none;
   }
 
@@ -185,12 +185,12 @@
     &:focus,
     &:hover {
       // background: rgba($bg-color, .5); // old spectre.css
-      background: color('bg-color', $alpha: .5);
-      opacity: .95;
+      background: color('bg-color', $alpha: 0.5);
+      opacity: 0.95;
     }
 
     &::before {
-      content: "\2715";
+      content: '\2715';
     }
   }
 }

--- a/src/_calendars.scss
+++ b/src/_calendars.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'mixins/shadow' as *;
 @use 'variables' as *;
 
@@ -70,7 +70,7 @@
       position: relative;
       text-align: center;
       text-decoration: none;
-      transition: background .2s, border .2s, box-shadow .2s, color .2s;
+      transition: background 0.2s, border 0.2s, box-shadow 0.2s, color 0.2s;
       vertical-align: middle;
       white-space: nowrap;
       width: $unit-7;
@@ -122,7 +122,7 @@
       &:disabled,
       &.disabled {
         cursor: default;
-        opacity: .25;
+        opacity: 0.25;
         pointer-events: none;
       }
     }
@@ -131,7 +131,7 @@
     &.next-month {
       .date-item,
       .calendar-event {
-        opacity: .25;
+        opacity: 0.25;
       }
     }
   }
@@ -142,7 +142,7 @@
     &::before {
       // background: $secondary-color; // old spectre.css
       background: color('secondary-color');
-      content: "";
+      content: '';
       height: $unit-7;
       left: 0;
       position: absolute;
@@ -197,7 +197,7 @@
         &:nth-child(7n) {
           border-right: 0;
         }
-        &:nth-last-child(-n+7) {
+        &:nth-last-child(-n + 7) {
           border-bottom: 0;
         }
       }

--- a/src/_cards.scss
+++ b/src/_cards.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'mixins/shadow' as *;
 @use 'variables' as *;
 
@@ -48,7 +48,7 @@
   }
 
   &.card-shadow {
-    @include shadow-variant(.1rem);
+    @include shadow-variant(0.1rem);
     border: 0;
   }
 }

--- a/src/_carousels.scss
+++ b/src/_carousels.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'variables' as *;
 
 // Carousels
@@ -6,7 +6,7 @@
 $carousel-number: 8;
 
 %carousel-image-checked {
-  animation: carousel-slidein .75s ease-in-out 1;
+  animation: carousel-slidein 0.75s ease-in-out 1;
   opacity: 1;
   z-index: $zindex-1;
 }
@@ -31,7 +31,7 @@ $carousel-number: 8;
     left: 0;
     position: relative;
     &::before {
-      content: "";
+      content: '';
       display: block;
       padding-bottom: 56.25%;
     }
@@ -57,15 +57,15 @@ $carousel-number: 8;
     .item-prev,
     .item-next {
       // background: rgba($gray-color-light, .25); // old spectre.css
-      background: color('gray-color-light', $alpha: .25);
+      background: color('gray-color-light', $alpha: 0.25);
       // border-color: rgba($gray-color-light, .5); // old spectre.css
-      border-color: color('gray-color-light', $alpha: .5);
+      border-color: color('gray-color-light', $alpha: 0.5);
       // color: $gray-color-light; // old spectre.css
       color: color('gray-color-light');
       opacity: 0;
       position: absolute;
       top: 50%;
-      transition: all .4s;
+      transition: all 0.4s;
       transform: translateY(-50%);
       z-index: $zindex-1;
     }
@@ -112,11 +112,11 @@ $carousel-number: 8;
 
       &::before {
         background: currentColor;
-        content: "";
+        content: '';
         display: block;
         height: $unit-h;
         position: absolute;
-        top: .5rem;
+        top: 0.5rem;
         width: 100%;
       }
     }

--- a/src/_chips.scss
+++ b/src/_chips.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'variables' as *;
 
 // Chips

--- a/src/_codes.scss
+++ b/src/_codes.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'mixins/label' as *;
 @use 'variables' as *;
 

--- a/src/_comparison-sliders.scss
+++ b/src/_comparison-sliders.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'variables' as *;
 
 // Image comparison slider
@@ -44,7 +44,7 @@
 
     &::before {
       background: transparent;
-      content: "";
+      content: '';
       cursor: default;
       height: 100%;
       left: 0;
@@ -60,7 +60,7 @@
       box-shadow: 0 -5px, 0 5px;
       // color: $light-color; // old spectre.css
       color: color('light-color');
-      content: "";
+      content: '';
       height: 3px;
       pointer-events: none;
       position: absolute;
@@ -93,7 +93,7 @@
 
   .comparison-label {
     // background: rgba($dark-color, .5); // old spectre.css
-    background: color('dark-color', $alpha: .5);
+    background: color('dark-color', $alpha: 0.5);
     bottom: $unit-4;
     // color: $light-color; // old spectre.css
     color: color('light-color');

--- a/src/_css-variables.scss
+++ b/src/_css-variables.scss
@@ -1,4 +1,5 @@
-@use 'mixins/css-variable-color' as *;
+@use 'mixins/define-color-based-on' as *;
+@use 'mixins/define-color' as *;
 @use 'variables' as *;
 
 /*

--- a/src/_empty.scss
+++ b/src/_empty.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'variables' as *;
 
 // Empty states (or Blank slates)

--- a/src/_filters.scss
+++ b/src/_filters.scss
@@ -1,4 +1,4 @@
-@use 'function' as *;
+@use 'functions' as *;
 @use 'variables' as *;
 
 // Filters

--- a/src/_filters.scss
+++ b/src/_filters.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'function' as *;
 @use 'variables' as *;
 
 // Filters

--- a/src/_forms.scss
+++ b/src/_forms.scss
@@ -1,5 +1,8 @@
+@use 'functions' as *;
 @use 'mixins/shadow' as *;
 @use 'variables' as *;
+
+// $transition: .2s;
 
 // Forms
 .form-group {
@@ -38,11 +41,14 @@ legend {
 // Form element: Input
 .form-input {
   appearance: none;
-  background: $bg-color-light;
+  // background: $bg-color-light; // old spectre.css
+  background: color('bg-color-light');
   background-image: none;
-  border: $border-width solid $border-color-dark;
+  // border: $border-width solid $border-color-dark; // old spectre.css
+  border: $border-width solid color('border-color-dark');
   border-radius: $border-radius;
-  color: $body-font-color;
+  // color: $body-font-color; // old spectre.css
+  color: color('body-font-color');
   display: block;
   font-size: $font-size;
   height: $control-size;
@@ -51,14 +57,16 @@ legend {
   outline: none;
   padding: $control-padding-y $control-padding-x;
   position: relative;
-  transition: background .2s, border .2s, box-shadow .2s, color .2s;
+  transition: background 0.2s, border 0.2s, box-shadow 0.2s, color 0.2s;
   width: 100%;
   &:focus {
     @include control-shadow();
-    border-color: $primary-color;
+    // border-color: $primary-color; // old spectre.css
+    border-color: color('primary-color');
   }
   &::placeholder {
-    color: $gray-color;
+    // color: $gray-color; // old spectre.css
+    color: color('gray-color');
   }
 
   // Input sizes
@@ -97,25 +105,29 @@ textarea.form-input {
 
 // Form element: Input hint
 .form-input-hint {
-  color: $gray-color;
+  // color: $gray-color; // old spectre.css
+  color: color('gray-color');
   font-size: $font-size-sm;
   margin-top: $unit-1;
 
   .has-success &,
   .is-success + & {
-    color: $success-color;
+    // color: $success-color; // old spectre.css
+    color: color('success-color');
   }
 
   .has-error &,
   .is-error + & {
-    color: $error-color;
+    // color: $error-color; // old spectre.css
+    color: color('error-color');
   }
 }
 
 // Form element: Select
 .form-select {
   appearance: none;
-  border: $border-width solid $border-color-dark;
+  // border: $border-width solid $border-color-dark; // old spectre.css
+  border: $border-width solid color('border-color-dark');
   border-radius: $border-radius;
   color: inherit;
   font-size: $font-size;
@@ -125,10 +137,12 @@ textarea.form-input {
   padding: $control-padding-y $control-padding-x;
   vertical-align: middle;
   width: 100%;
-  background: $bg-color-light;
+  // background: $bg-color-light; // old spectre.css
+  background: color('bg-color-light');
   &:focus {
     @include control-shadow();
-    border-color: $primary-color;
+    // border-color: $primary-color; // old spectre.css
+    border-color: color('primary-color');
   }
   &::-ms-expand {
     display: none;
@@ -158,7 +172,8 @@ textarea.form-input {
     }
   }
   &:not([multiple]):not([size]) {
-    background: $bg-color-light url("data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%204%205'%3E%3Cpath%20fill='%23667189'%20d='M2%200L0%202h4zm0%205L0%203h4z'/%3E%3C/svg%3E") no-repeat right .35rem center / .4rem .5rem;
+    // background: $bg-color-light url("data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%204%205'%3E%3Cpath%20fill='%23667189'%20d='M2%200L0%202h4zm0%205L0%203h4z'/%3E%3C/svg%3E") no-repeat right .35rem center / .4rem .5rem; // old spectre.css
+    background: color('bg-color-light') url("data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%204%205'%3E%3Cpath%20fill='%23667189'%20d='M2%200L0%202h4zm0%205L0%203h4z'/%3E%3C/svg%3E") no-repeat right 0.35rem center / 0.4rem 0.5rem;
     padding-right: $control-icon-size + $control-padding-x;
   }
 }
@@ -219,20 +234,24 @@ textarea.form-input {
     width: 1px;
     &:focus + .form-icon {
       @include control-shadow();
-      border-color: $primary-color;
+      // border-color: $primary-color; // old spectre.css
+      border-color: color('primary-color');
     }
     &:checked + .form-icon {
-      background: $primary-color;
-      border-color: $primary-color;
+      // background: $primary-color; // old spectre.css
+      background: color('primary-color');
+      // border-color: $primary-color; // old spectre.css
+      border-color: color('primary-color');
     }
   }
 
   .form-icon {
-    border: $border-width solid $border-color-dark;
+    // border: $border-width solid $border-color-dark; // old spectre.css
+    border: $border-width solid color('border-color-dark');
     cursor: pointer;
     display: inline-block;
     position: absolute;
-    transition: background .2s, border .2s, box-shadow .2s, color .2s;
+    transition: background 0.2s, border 0.2s, box-shadow 0.2s, color 0.2s;
   }
 
   // Input checkbox, radio and switch sizes
@@ -250,7 +269,8 @@ textarea.form-input {
 .form-checkbox,
 .form-radio {
   .form-icon {
-    background: $bg-color-light;
+    // background: $bg-color-light; // old spectre.css
+    background: color('bg-color-light');
     height: $control-icon-size;
     left: 0;
     top: ($control-size-sm - $control-icon-size) / 2;
@@ -259,7 +279,8 @@ textarea.form-input {
 
   input {
     &:active + .form-icon {
-      background: $bg-color-dark;
+      // background: $bg-color-dark; // old spectre.css
+      background: color('bg-color-dark');
     }
   }
 }
@@ -272,7 +293,8 @@ textarea.form-input {
     &:checked + .form-icon {
       &::before {
         background-clip: padding-box;
-        border: $border-width-lg solid $light-color;
+        // border: $border-width-lg solid $light-color; // old spectre.css
+        border: $border-width-lg solid color('light-color');
         border-left-width: 0;
         border-top-width: 0;
         content: "";
@@ -287,10 +309,13 @@ textarea.form-input {
       }
     }
     &:indeterminate + .form-icon {
-      background: $primary-color;
-      border-color: $primary-color;
+      // background: $primary-color; // old spectre.css
+      background: color('primary-color');
+      // border-color: $primary-color; // old spectre.css
+      border-color: color('primary-color');
       &::before {
-        background: $bg-color-light;
+        // background: $bg-color-light; // old spectre.css
+        background: color('bg-color-light');
         content: "";
         height: 2px;
         left: 50%;
@@ -311,7 +336,8 @@ textarea.form-input {
   input {
     &:checked + .form-icon {
       &::before {
-        background: $bg-color-light;
+        // background: $bg-color-light; // old spectre.css
+        background: color('bg-color-light');
         border-radius: 50%;
         content: "";
         height: 6px;
@@ -330,7 +356,8 @@ textarea.form-input {
   padding-left: ($unit-8 + $control-padding-x);
 
   .form-icon {
-    background: $gray-color;
+    // background: $gray-color; // old spectre.css
+    background: color('gray-color');
     background-clip: padding-box;
     border-radius: $unit-2 + $border-width;
     height: $unit-4 + $border-width * 2;
@@ -338,7 +365,8 @@ textarea.form-input {
     top: ($control-size-sm - $unit-4) / 2 - $border-width;
     width: $unit-8;
     &::before {
-      background: $bg-color-light;
+      // background: $bg-color-light; // old spectre.css
+      background: color('bg-color-light');
       border-radius: 50%;
       content: "";
       display: block;
@@ -346,7 +374,7 @@ textarea.form-input {
       left: 0;
       position: absolute;
       top: 0;
-      transition: background .2s, border .2s, box-shadow .2s, color .2s, left .2s;
+      transition: background 0.2s, border 0.2s, box-shadow 0.2s, color 0.2s, left 0.2s;
       width: $unit-4;
     }
   }
@@ -359,7 +387,8 @@ textarea.form-input {
     }
     &:active + .form-icon {
       &::before {
-        background: $bg-color;
+        // background: $bg-color; // old spectre.css
+        background: color('bg-color');
       }
     }
   }
@@ -370,8 +399,10 @@ textarea.form-input {
   display: flex;
 
   .input-group-addon {
-    background: $bg-color;
-    border: $border-width solid $border-color-dark;
+    // background: $bg-color; // old spectre.css
+    background: color('bg-color');
+    border: $border-width solid $border-color-dark; // old spectre.css
+    border: $border-width solid color('border-color-dark');
     border-radius: $border-radius;
     line-height: $line-height;
     padding: $control-padding-y $control-padding-x;
@@ -434,8 +465,10 @@ textarea.form-input {
 .form-select {
   .has-success &,
   &.is-success {
-    background: lighten($success-color, 53%);
-    border-color: $success-color;
+    // background: lighten($success-color, 53%); // old spectre.css
+    background: color('success-color', $lightness: +53%);
+    // border-color: $success-color; // old spectre.css
+    border-color: color('success-color');
     &:focus {
       // @include control-shadow($success-color); // old spectre.css
       @include control-shadow('success-color');
@@ -444,8 +477,10 @@ textarea.form-input {
 
   .has-error &,
   &.is-error {
-    background: lighten($error-color, 53%);
-    border-color: $error-color;
+    // background: lighten($error-color, 53%); // old spectre.css
+    background: color('error-color', $lightness: +53%);
+    // border-color: $error-color; // old spectre.css
+    border-color: color('error-color');
     &:focus {
       // @include control-shadow($error-color); // old spectre.css
       @include control-shadow('error-color');
@@ -459,19 +494,23 @@ textarea.form-input {
   .has-error &,
   &.is-error {
     .form-icon {
-      border-color: $error-color;
+      // border-color: $error-color; // old spectre.css
+      border-color: color('error-color');
     }
 
     input {
       &:checked + .form-icon {
-        background: $error-color;
-        border-color: $error-color;
+        // background: $error-color; // old spectre.css
+        background: color('error-color');
+        // border-color: $error-color; // old spectre.css
+        border-color: color('error-color');
       }
 
       &:focus + .form-icon {
         // @include control-shadow($error-color); // old spectre.css
         @include control-shadow('error-color');
-        border-color: $error-color;
+        // border-color: $error-color; // old spectre.css
+        border-color: color('error-color');
       }
     }
   }
@@ -482,8 +521,10 @@ textarea.form-input {
   &.is-error {
     input {
       &:indeterminate + .form-icon {
-        background: $error-color;
-        border-color: $error-color;
+        // background: $error-color; // old spectre.css
+        background: color('error-color');
+        // border-color: $error-color; // old spectre.css
+        border-color: color('error-color');
       }
     }
   }
@@ -493,15 +534,18 @@ textarea.form-input {
 .form-input {
   &:not(:placeholder-shown) {
     &:invalid {
-      border-color: $error-color;
+      // border-color: $error-color; // old spectre.css
+      border-color: color('error-color');
       &:focus {
         // @include control-shadow($error-color); // old spectre.css
         @include control-shadow('error-color');
-        background: lighten($error-color, 53%);
+        // background: lighten($error-color, 53%); // old spectre.css
+        background: color('error-color', $lighten: +53%);
       }
 
       & + .form-input-hint {
-        color: $error-color;
+        // color: $error-color; // old spectre.css
+        color: color('error-color');
       }
     }
   }
@@ -512,7 +556,8 @@ textarea.form-input {
 .form-select {
   &:disabled,
   &.disabled {
-    background-color: $bg-color-dark;
+    // background-color: $bg-color-dark; // old spectre.css
+    background-color: color('bg-color-dark');
     cursor: not-allowed;
     opacity: .5;
   }
@@ -520,7 +565,8 @@ textarea.form-input {
 
 .form-input {
   &[readonly] {
-    background-color: $bg-color;
+    // background-color: $bg-color; // old spectre.css
+    background-color: color('bg-color');
   }
 }
 
@@ -528,7 +574,8 @@ input {
   &:disabled,
   &.disabled {
     & + .form-icon {
-      background: $bg-color-dark;
+      // background: $bg-color-dark; // old spectre.css
+      background: color('bg-color-dark');
       cursor: not-allowed;
       opacity: .5;
     }
@@ -540,7 +587,8 @@ input {
     &:disabled,
     &.disabled {
       & + .form-icon::before {
-        background: $bg-color-light;
+        // background: $bg-color-light; // old spectre.css
+        background: color('bg-color-light');
       }
     }
   }

--- a/src/_forms.scss
+++ b/src/_forms.scss
@@ -540,7 +540,7 @@ textarea.form-input {
         // @include control-shadow($error-color); // old spectre.css
         @include control-shadow('error-color');
         // background: lighten($error-color, 53%); // old spectre.css
-        background: color('error-color', $lighten: +53%);
+        background: color('error-color', $lightness: +53%);
       }
 
       & + .form-input-hint {

--- a/src/_labels.scss
+++ b/src/_labels.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'mixins/label' as *;
 @use 'variables' as *;
 
@@ -12,8 +12,8 @@
   // Label rounded
   &.label-rounded {
     border-radius: 5rem;
-    padding-left: .4rem;
-    padding-right: .4rem;
+    padding-left: 0.4rem;
+    padding-right: 0.4rem;
   }
 
   // Label colors

--- a/src/_media.scss
+++ b/src/_media.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'variables' as *;
 
 // Media
@@ -27,7 +27,7 @@
   position: relative;
   width: 100%;
   &::before {
-    content: "";
+    content: '';
     display: block;
     padding-bottom: 56.25%; // Default ratio 16:9, you can calculate this value by dividing 9 by 16
   }

--- a/src/_menus.scss
+++ b/src/_menus.scss
@@ -1,10 +1,10 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'mixins/shadow' as *;
 @use 'variables' as *;
 
 // Menus
 .menu {
-  @include shadow-variant(.05rem);
+  @include shadow-variant(0.05rem);
   // background: $bg-color-light; // old spectre.css
   background: color('bg-color-light');
   border-radius: $border-radius;

--- a/src/_meters.scss
+++ b/src/_meters.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'variables' as *;
 
 // Meters

--- a/src/_modals.scss
+++ b/src/_modals.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'mixins/shadow' as *;
 @use 'variables' as *;
 
@@ -24,7 +24,7 @@
 
     .modal-overlay {
       // background: rgba($bg-color, .75); // old spectre.css
-      background: color('bg-color', $alpha: .75);
+      background: color('bg-color', $alpha: 0.75);
       bottom: 0;
       cursor: default;
       display: block;
@@ -35,7 +35,7 @@
     }
 
     .modal-container {
-      animation: slide-down .2s ease 1;
+      animation: slide-down 0.2s ease 1;
       z-index: $zindex-0;
     }
   }
@@ -61,7 +61,7 @@
 }
 
 .modal-container {
-  @include shadow-variant(.2rem);
+  @include shadow-variant(0.2rem);
   background: $bg-color-light;
   border-radius: $border-radius;
   display: flex;

--- a/src/_navs.scss
+++ b/src/_navs.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'variables' as *;
 
 // Navs

--- a/src/_off-canvas.scss
+++ b/src/_off-canvas.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'variables' as *;
 
 // Off canvas menus
@@ -32,7 +32,7 @@ $off-canvas-breakpoint: $size-lg !default;
     overflow-y: auto;
     position: fixed;
     top: 0;
-    transition: transform .25s;
+    transition: transform 0.25s;
     z-index: $zindex-2;
     @if $rtl == true {
       right: 0;
@@ -51,7 +51,7 @@ $off-canvas-breakpoint: $size-lg !default;
 
   .off-canvas-overlay {
     // background: rgba($dark-color, .1); // old spectre.css
-    background: color('dark-color', $alpha: .1);
+    background: color('dark-color', $alpha: 0.1);
     border-color: transparent;
     border-radius: 0;
     bottom: 0;

--- a/src/_pagination.scss
+++ b/src/_pagination.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'variables' as *;
 
 // Pagination
@@ -31,7 +31,7 @@
     &.disabled {
       a {
         cursor: default;
-        opacity: .5;
+        opacity: 0.5;
         pointer-events: none;
       }
     }
@@ -60,7 +60,7 @@
 
     .page-item-subtitle {
       margin: 0;
-      opacity: .5;
+      opacity: 0.5;
     }
   }
 }

--- a/src/_panels.scss
+++ b/src/_panels.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'variables' as *;
 
 // Panels

--- a/src/_parallax.scss
+++ b/src/_parallax.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'mixins/shadow' as *;
 @use 'variables' as *;
 
@@ -7,8 +7,8 @@ $parallax-deg: 3deg !default;
 $parallax-offset: 4.5px !default;
 $parallax-offset-z: 50px !default;
 $parallax-perspective: 1000px !default;
-$parallax-scale: .95 !default;
-$parallax-fade-color: rgba(255, 255, 255, .35) !default; // TODO: Add color.
+$parallax-scale: 0.95 !default;
+$parallax-fade-color: rgba(255, 255, 255, 0.35) !default; // TODO: Add color.
 
 // Mixin: Parallax direction
 @mixin parallax-dir() {
@@ -30,11 +30,11 @@ $parallax-fade-color: rgba(255, 255, 255, .35) !default; // TODO: Add color.
     height: auto;
     transform: perspective($parallax-perspective);
     transform-style: preserve-3d;
-    transition: all .4s ease;
+    transition: all 0.4s ease;
     width: 100%;
 
     &::before {
-      content: "";
+      content: '';
       display: block;
       height: 100%;
       left: 0;
@@ -58,7 +58,7 @@ $parallax-fade-color: rgba(255, 255, 255, .35) !default; // TODO: Add color.
     text-shadow: 0 0 20px color('dark-color', $alpha: 0.75);
     top: 0;
     transform: translateZ($parallax-offset-z) scale($parallax-scale);
-    transition: transform .4s;
+    transition: transform 0.4s;
     width: 100%;
     z-index: $zindex-0;
   }

--- a/src/_popovers.scss
+++ b/src/_popovers.scss
@@ -13,7 +13,7 @@
     position: absolute;
     top: 0;
     transform: translate(-50%, -50%) scale(0);
-    transition: transform .2s;
+    transition: transform 0.2s;
     width: $control-width-sm;
     z-index: $zindex-3;
   }
@@ -62,7 +62,7 @@
   }
 
   .card {
-    @include shadow-variant(.2rem);
+    @include shadow-variant(0.2rem);
     border: 0;
   }
 }

--- a/src/_progress.scss
+++ b/src/_progress.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'variables' as *;
 
 // Progress

--- a/src/_sliders.scss
+++ b/src/_sliders.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'mixins/shadow' as *;
 @use 'variables' as *;
 
@@ -33,7 +33,7 @@
     // margin-top: -($unit-3 - $unit-h) / 2; // old spectre.css
     margin-top: -($unit-3 - $unit-h) * 0.5;
 
-    transition: transform .2s;
+    transition: transform 0.2s;
     width: $unit-3;
   }
   &::-moz-range-thumb {
@@ -42,7 +42,7 @@
     border: 0;
     border-radius: 50%;
     height: $unit-3;
-    transition: transform .2s;
+    transition: transform 0.2s;
     width: $unit-3;
   }
   &::-ms-thumb {
@@ -51,7 +51,7 @@
     border: 0;
     border-radius: 50%;
     height: $unit-3;
-    transition: transform .2s;
+    transition: transform 0.2s;
     width: $unit-3;
   }
 

--- a/src/_steps.scss
+++ b/src/_steps.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'variables' as *;
 
 // Steps
@@ -19,7 +19,7 @@
     &:not(:first-child)::before {
       // background: $primary-color; // old spectre.css
       background: color('primary-color');
-      content: "";
+      content: '';
       height: 2px;
       left: -50%;
       position: absolute;
@@ -40,7 +40,7 @@
         // border: $border-width-lg solid $light-color; // old spectre.css
         border: $border-width-lg solid color('light-color');
         border-radius: 50%;
-        content: "";
+        content: '';
         display: block;
         height: $unit-3;
         left: 50%;

--- a/src/_tables.scss
+++ b/src/_tables.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'variables' as *;
 
 // Tables
@@ -48,7 +48,7 @@
   &.table-scroll {
     display: block;
     overflow-x: auto;
-    padding-bottom: .75rem;
+    padding-bottom: 0.75rem;
     white-space: nowrap;
   }
 

--- a/src/_tabs.scss
+++ b/src/_tabs.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'variables' as *;
 
 // Tabs

--- a/src/_timelines.scss
+++ b/src/_timelines.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'variables' as *;
 
 // Timelines
@@ -10,7 +10,7 @@
     &::before {
       // background: $border-color; // old spectre.css
       background: color('border-color');
-      content: "";
+      content: '';
       height: 100%;
       left: 11px;
       position: absolute;
@@ -41,7 +41,7 @@
         // border: $border-width-lg solid $primary-color; // old spectre.css
         border: $border-width-lg solid color('primary-color');
         border-radius: 50%;
-        content: "";
+        content: '';
         display: block;
         height: $unit-2;
         left: $unit-2;

--- a/src/_toasts.scss
+++ b/src/_toasts.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'mixins/toast' as *;
 @use 'variables' as *;
 
@@ -44,7 +44,7 @@
     &:hover,
     &:active,
     &.active {
-      opacity: .75;
+      opacity: 0.75;
     }
   }
 

--- a/src/_tooltips.scss
+++ b/src/_tooltips.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'variables' as *;
 
 // Tooltips
@@ -6,7 +6,7 @@
   position: relative;
   &::after {
     // background: rgba($dark-color, .95);
-    background: color('dark-color', $alpha: .95);
+    background: color('dark-color', $alpha: 0.95);
     border-radius: $border-radius;
     bottom: 100%;
     // color: $light-color; // old spectre.css
@@ -23,7 +23,7 @@
     position: absolute;
     text-overflow: ellipsis;
     transform: translate(-50%, $unit-2);
-    transition: opacity .2s, transform .2s;
+    transition: opacity 0.2s, transform 0.2s;
     white-space: pre;
     z-index: $zindex-3;
   }

--- a/src/_typography.scss
+++ b/src/_typography.scss
@@ -1,4 +1,4 @@
-@use 'function/css-variable-color' as *;
+@use 'functions' as *;
 @use 'mixins/label' as *;
 @use 'variables' as *;
 
@@ -13,7 +13,7 @@ h6 {
   color: inherit;
   font-weight: 500;
   line-height: 1.2;
-  margin-bottom: .5em;
+  margin-bottom: 0.5em;
   margin-top: 0;
 }
 .h1,
@@ -46,7 +46,7 @@ h5,
 }
 h6,
 .h6 {
-  font-size: .8rem;
+  font-size: 0.8rem;
 }
 
 // Paragraphs

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -1,17 +1,17 @@
 // Core variables
-$version: "1.0.0-alpha";
+$version: "1.0.0-alpha.1";
 
 // Core features
 $rtl: false !default;
 
 // Core colors
+$accent-color: #9932CC !default;
 $primary-color: #5755d9 !default;
 $primary-color-dark: darken($primary-color, 3%) !default;
 $primary-color-light: lighten($primary-color, 3%) !default;
 $secondary-color: lighten($primary-color, 37.5%) !default;
 $secondary-color-dark: darken($secondary-color, 3%) !default;
 $secondary-color-light: lighten($secondary-color, 3%) !default;
-$accent-color: #9932CC !default;
 
 // Gray colors
 $dark-color: #303742 !default;

--- a/src/functions/_color.scss
+++ b/src/functions/_color.scss
@@ -1,4 +1,4 @@
-// Color variable.
+// Get color from css variable.
 @function color($name, $hue: 0deg, $lightness: 0%, $saturation: 0%, $alpha: 1) {
   @return hsla(
     calc(var(--s-#{$name}-h) + #{$hue}),

--- a/src/functions/index.scss
+++ b/src/functions/index.scss
@@ -1,0 +1,1 @@
+@forward 'color';

--- a/src/icons/_icons-action.scss
+++ b/src/icons/_icons-action.scss
@@ -9,8 +9,8 @@
     border: $icon-border-width solid currentColor;
     border-bottom: 0;
     border-right: 0;
-    height: .45em;
-    width: .45em;
+    height: 0.45em;
+    width: 0.45em;
   }
   &::before {
     transform: translate(-50%, -90%) rotate(45deg);
@@ -34,7 +34,7 @@
 .icon-more-vert {
   &::before {
     background: currentColor;
-    box-shadow: -.4em 0, .4em 0;
+    box-shadow: -0.4em 0, 0.4em 0;
     border-radius: 50%;
     height: 3px;
     width: 3px;
@@ -43,7 +43,7 @@
 
 .icon-more-vert {
   &::before {
-    box-shadow: 0 -.4em, 0 .4em;
+    box-shadow: 0 -0.4em, 0 0.4em;
   }
 }
 
@@ -86,8 +86,8 @@
     border: $icon-border-width solid currentColor;
     border-right: 0;
     border-top: 0;
-    height: .5em;
-    width: .9em;
+    height: 0.5em;
+    width: 0.9em;
     transform: translate(-50%, -75%) rotate(-45deg);
   }
 }
@@ -111,9 +111,9 @@
   border-top-color: transparent;
   &::before {
     background: currentColor;
-    content: "";
-    height: .5em;
-    top: .1em;
+    content: '';
+    height: 0.5em;
+    top: 0.1em;
     width: $icon-border-width;
   }
 }
@@ -128,7 +128,7 @@
     width: 1em;
   }
   &::after {
-    border: .2em solid currentColor;
+    border: 0.2em solid currentColor;
     border-top-color: transparent;
     border-left-color: transparent;
     height: 0;
@@ -143,11 +143,11 @@
   &::before {
     border: $icon-border-width solid currentColor;
     border-radius: 50%;
-    height: .75em;
+    height: 0.75em;
     left: 5%;
     top: 5%;
     transform: translate(0, 0) rotate(45deg);
-    width: .75em;
+    width: 0.75em;
   }
   &::after {
     background: currentColor;
@@ -155,7 +155,7 @@
     left: 80%;
     top: 80%;
     transform: translate(-50%, -50%) rotate(45deg);
-    width: .4em;
+    width: 0.4em;
   }
 }
 
@@ -163,12 +163,12 @@
 .icon-edit {
   &::before {
     border: $icon-border-width solid currentColor;
-    height: .4em;
+    height: 0.4em;
     transform: translate(-40%, -60%) rotate(-45deg);
-    width: .85em;
+    width: 0.85em;
   }
   &::after {
-    border: .15em solid currentColor;
+    border: 0.15em solid currentColor;
     border-top-color: transparent;
     border-right-color: transparent;
     height: 0;
@@ -186,16 +186,16 @@
     border-bottom-left-radius: $border-radius;
     border-bottom-right-radius: $border-radius;
     border-top: 0;
-    height: .75em;
+    height: 0.75em;
     top: 60%;
-    width: .75em;
+    width: 0.75em;
   }
   &::after {
     background: currentColor;
-    box-shadow: -.25em .2em, .25em .2em;
+    box-shadow: -0.25em 0.2em, 0.25em 0.2em;
     height: $icon-border-width;
     top: $icon-border-width * 0.5;
-    width: .5em;
+    width: 0.5em;
   }
 }
 
@@ -209,19 +209,19 @@
     border: $icon-border-width solid currentColor;
     border-left: 0;
     border-top: 0;
-    height: .4em;
+    height: 0.4em;
     left: 100%;
-    top: .25em;
+    top: 0.25em;
     transform: translate(-125%, -50%) rotate(-45deg);
-    width: .4em;
+    width: 0.4em;
   }
   &::after {
     border: $icon-border-width solid currentColor;
     border-bottom: 0;
     border-right: 0;
     border-radius: 75% 0;
-    height: .5em;
-    width: .6em;
+    height: 0.5em;
+    width: 0.6em;
   }
 }
 
@@ -238,10 +238,10 @@
     border-bottom-right-radius: $border-radius;
     border-left: 0;
     border-top-right-radius: $border-radius;
-    height: .65em;
+    height: 0.65em;
     top: 35%;
     left: 60%;
-    width: .8em;
+    width: 0.8em;
   }
 }
 
@@ -252,17 +252,17 @@
     border-bottom: 0;
     border-top-left-radius: $border-radius;
     border-top-right-radius: $border-radius;
-    height: .9em;
-    width: .8em;
+    height: 0.9em;
+    width: 0.8em;
   }
   &::after {
     border: $icon-border-width solid currentColor;
     border-bottom: 0;
     border-left: 0;
     border-radius: $border-radius;
-    height: .5em;
+    height: 0.5em;
     transform: translate(-50%, 35%) rotate(-45deg) skew(15deg, 15deg);
-    width: .5em;
+    width: 0.5em;
   }
 }
 
@@ -274,13 +274,13 @@
     border: $icon-border-width solid currentColor;
     border-bottom: 0;
     border-right: 0;
-    height: .5em;
-    width: .5em;
+    height: 0.5em;
+    width: 0.5em;
     transform: translate(-50%, -60%) rotate(-135deg);
   }
   &::after {
     background: currentColor;
-    height: .6em;
+    height: 0.6em;
     top: 40%;
     width: $icon-border-width;
   }
@@ -302,18 +302,18 @@
     border-radius: $border-radius;
     border-right: 0;
     border-bottom: 0;
-    height: .8em;
+    height: 0.8em;
     left: 40%;
     top: 35%;
-    width: .8em;
+    width: 0.8em;
   }
   &::after {
     border: $icon-border-width solid currentColor;
     border-radius: $border-radius;
-    height: .8em;
+    height: 0.8em;
     left: 60%;
     top: 60%;
-    width: .8em;
+    width: 0.8em;
   }
 }
 
@@ -323,22 +323,22 @@
   &::before {
     border: $icon-border-width solid currentColor;
     border-radius: 0 50% 0 50%;
-    content: "";
+    content: '';
     height: 1em;
     left: 0;
     top: 25%;
     transform: rotate(-45deg);
-    transform-origin: .2em .3em;
+    transform-origin: 0.2em 0.3em;
     width: 1em;
   }
   &::after {
     border: $icon-border-width solid currentColor;
     border-radius: 50%;
-    content: "";
-    height: .4em;
+    content: '';
+    height: 0.4em;
     left: 55%;
     top: 45%;
-    width: .4em;
+    width: 0.4em;
   }
 }
 
@@ -349,7 +349,7 @@
     border-radius: 0;
     height: 1.58em;
     left: 1.08em;
-    top: -.1em;
+    top: -0.1em;
     transform: rotate(45deg);
     transform-origin: 0 0;
     width: $icon-border-width;

--- a/src/mixins/_button.scss
+++ b/src/mixins/_button.scss
@@ -1,4 +1,4 @@
-@use '../function/css-variable-color' as *;
+@use '../functions' as *;
 @use 'shadow' as *;
 @use '../variables' as *;
 
@@ -35,7 +35,6 @@
     border-color: color($color, $lightness: -10%);
     // color: $light-color; // old spectre.css
     color: color('light-color');
-
   }
   &.loading {
     &::after {

--- a/src/mixins/_clearfix.scss
+++ b/src/mixins/_clearfix.scss
@@ -2,7 +2,7 @@
 @mixin clearfix() {
   &::after {
     clear: both;
-    content: "";
+    content: '';
     display: table;
   }
 }

--- a/src/mixins/_color.scss
+++ b/src/mixins/_color.scss
@@ -1,11 +1,11 @@
-@use '../function/css-variable-color' as *;
+@use '../functions' as *;
 @use '../variables' as *;
 
 // Background color utility mixin
 @mixin bg-color-variant(
   $name: '.bg-primary',
   $color: 'primary-color',
-  $hexColor: $primary-color
+  $hex-color: $primary-color
 ) {
   #{$name} {
     // background: $color !important; // old spectre.
@@ -15,7 +15,7 @@
     // @if (lightness($color) < 60) {
     // color: $light-color;
     // }
-    @if (lightness($hexColor) < 60) {
+    @if (lightness($hex-color) < 60) {
       color: color('light-color');
     }
   }
@@ -25,7 +25,7 @@
 @mixin text-color-variant($name: '.text-primary', $color: 'primary-color') {
   #{$name} {
     // color: $color !important; // old spectre.
-    color: color($color);
+    color: color($color) !important;
   }
 
   a#{$name} {

--- a/src/mixins/_define-color-based-on.scss
+++ b/src/mixins/_define-color-based-on.scss
@@ -1,11 +1,3 @@
-// Define color.
-@mixin define-color($name, $color) {
-  --s-#{$name}-h: #{hue($color)};
-  --s-#{$name}-l: #{lightness($color)};
-  --s-#{$name}-s: #{saturation($color)};
-  --s-#{$name}-a: #{alpha($color)};
-}
-
 // Defines a color based on the specified CSS variable and its lightness.
 @mixin define-color-based-on($name, $color, $lightness: 0%) {
   --s-#{$name}-h: var(--s-#{$color}-h);

--- a/src/mixins/_define-color.scss
+++ b/src/mixins/_define-color.scss
@@ -1,0 +1,7 @@
+// Defines CSS variable color in hsl form.
+@mixin define-color($name, $color) {
+  --s-#{$name}-h: #{hue($color)};
+  --s-#{$name}-l: #{lightness($color)};
+  --s-#{$name}-s: #{saturation($color)};
+  --s-#{$name}-a: #{alpha($color)};
+}

--- a/src/mixins/_label.scss
+++ b/src/mixins/_label.scss
@@ -1,4 +1,4 @@
-@use '../function/css-variable-color' as *;
+@use '../functions' as *;
 @use '../variables' as *;
 
 // Label base style

--- a/src/mixins/_shadow.scss
+++ b/src/mixins/_shadow.scss
@@ -1,15 +1,15 @@
-@use '../function/css-variable-color' as *;
+@use '../functions' as *;
 @use '../variables' as *;
 
 // Component focus shadow
 // @mixin control-shadow($color: $primary-color) { // old spectre.css
 @mixin control-shadow($color: 'primary-color') {
   // box-shadow: 0 0 0 .1rem rgba($color, .2); // old spectre.css
-  box-shadow: 0 0 0 .1rem color($color, $alpha: .2);
+  box-shadow: 0 0 0 0.1rem color($color, $alpha: 0.2);
 }
 
 // Shadow mixin
 @mixin shadow-variant($offset) {
   // box-shadow: 0 $offset ($offset + .05rem) * 2 rgba($dark-color, .15); // old spectre.css
-  box-shadow: 0 $offset ($offset + .05rem) * 2 color('dark-color', $alpha: .15);
+  box-shadow: 0 $offset ($offset + 0.05rem) * 2 color('dark-color', $alpha: 0.15);
 }

--- a/src/mixins/_toast.scss
+++ b/src/mixins/_toast.scss
@@ -1,11 +1,11 @@
-@use '../function/css-variable-color' as *;
+@use '../functions' as *;
 @use '../variables' as *;
 
 // Toast variant mixin
 // @mixin toast-variant($color: $dark-color) { // old spectre.css
 @mixin toast-variant($color: 'dark-color') {
   // background: rgba($color, .95); // old spectre.css
-  background: color($color, $alpha: .95);
+  background: color($color, $alpha: 0.95);
   // border-color: $color; // old spectre.css
   border-color: color($color);
 }

--- a/src/spectre-exp.scss
+++ b/src/spectre-exp.scss
@@ -1,6 +1,6 @@
 // Variables and mixins
-@forward 'variables';
-@forward 'mixins';
+// @forward 'mixins';
+// @forward 'variables';
 @use 'variables' as *;
 
 /*! Spectre.css Experimentals v#{$version} | MIT License | github.com/picturepan2/spectre */

--- a/src/spectre-icons.scss
+++ b/src/spectre-icons.scss
@@ -1,6 +1,6 @@
 // Variables and mixins
-@forward 'variables';
-@forward 'mixins';
+// @forward 'mixins';
+// @forward 'variables';
 @use 'variables' as *;
 
 /*! Spectre.css Icons v#{$version} | MIT License | github.com/picturepan2/spectre */

--- a/src/utilities/_colors.scss
+++ b/src/utilities/_colors.scss
@@ -50,6 +50,6 @@
   Gray colors.
 */
 // @include bg-color-variant('.bg-gray', $bg-color); // old.spectre.css
-@include bg-color-variant('.bg-gray', 'bg-gray', $gray-color); // ? .bg-gray is not $bg-color but directly $gray-color.
+@include bg-color-variant('.bg-gray', 'gray-color', $gray-color); // ? .bg-gray is not $bg-color but directly $gray-color.
 @include bg-color-variant('.bg-gray-dark', 'gray-color-dark', $gray-color-dark); // ! New color.
 @include bg-color-variant('.bg-gray-light', 'gray-color-light', $gray-color-light); // ! New color.

--- a/src/utilities/_colors.scss
+++ b/src/utilities/_colors.scss
@@ -50,6 +50,6 @@
   Gray colors.
 */
 // @include bg-color-variant('.bg-gray', $bg-color); // old.spectre.css
-@include bg-color-variant('.bg-gray', 'bg-gray', $bg-gray); // ? .bg-gray is not $bg-color but directly $bg-gray.
+@include bg-color-variant('.bg-gray', 'bg-gray', $gray-color); // ? .bg-gray is not $bg-color but directly $gray-color.
 @include bg-color-variant('.bg-gray-dark', 'gray-color-dark', $gray-color-dark); // ! New color.
 @include bg-color-variant('.bg-gray-light', 'gray-color-light', $gray-color-light); // ! New color.

--- a/src/utilities/_colors.scss
+++ b/src/utilities/_colors.scss
@@ -1,49 +1,55 @@
-@use '../mixins/color.scss' as *;
-@use '../variables.scss' as *;
+@use '../mixins/color' as *;
+@use '../variables' as *;
 
-// Text colors
-// @include text-color-variant(".text-primary", $primary-color); // old spectre.css
-@include text-color-variant(".text-primary", 'primary-color');
+/*
+  Text colors
+*/
+// @include text-color-variant('.text-primary', $primary-color); // old spectre.css
+@include text-color-variant('.text-primary', 'primary-color');
+// @include text-color-variant('.text-secondary', $secondary-color-dark); // old spectre.css
+@include text-color-variant('.text-secondary', 'secondary-color-dark');
+// @include text-color-variant('.text-gray', $gray-color); // old spectre.css
+@include text-color-variant('.text-gray', 'gray-color');
+// @include text-color-variant('.text-light', $light-color); // old spectre.css
+@include text-color-variant('.text-light', 'light-color');
+// @include text-color-variant('.text-dark', $body-font-color); // old spectre.css
+@include text-color-variant('.text-dark', 'body-font-color');
+// @include text-color-variant('.text-success', $success-color); // old spectre.css
+@include text-color-variant('.text-success', 'success-color');
+// @include text-color-variant('.text-warning', $warning-color); // old spectre.css
+@include text-color-variant('.text-warning', 'warning-color');
+// @include text-color-variant('.text-error', $error-color); // old spectre.css
+@include text-color-variant('.text-error', 'error-color');
 
-// @include text-color-variant(".text-secondary", $secondary-color-dark); // old spectre.css
-@include text-color-variant(".text-secondary", 'secondary-color-dark');
+/*
+  Background colors
+*/
+// BG core colors
+@include bg-color-variant('.bg', 'bg-color', $bg-color); // ! New color, it's an old .bg-gray
+@include bg-color-variant('.bg-accent', 'accent-color', $accent-color); // ! New color.
+// @include bg-color-variant('.bg-dark', $dark-color); // old.spectre.css
+@include bg-color-variant('.bg-dark', 'dark-color', $dark-color);
+@include bg-color-variant('.bg-light', 'light-color', $light-color);
+// @include bg-color-variant('.bg-primary', $primary-color); // old spectre.css
+@include bg-color-variant('.bg-primary', 'primary-color', $primary-color);
+// @include bg-color-variant('.bg-secondary', $secondary-color); // old.spectre.css
+@include bg-color-variant('.bg-secondary', 'secondary-color', $secondary-color);
 
-// @include text-color-variant(".text-gray", $gray-color); // old spectre.css
-@include text-color-variant(".text-gray", 'gray-color');
+/*
+  Control colors.
+*/
+// @include bg-color-variant('.bg-error', $error-color); // old.spectre.css
+@include bg-color-variant('.bg-error', 'error-color', $error-color);
+@include bg-color-variant('.bg-info', 'info-color', $info-color); // ! New color.
+// @include bg-color-variant('.bg-success', $success-color); // old.spectre.css
+@include bg-color-variant('.bg-success', 'success-color', $success-color);
+// @include bg-color-variant('.bg-warning', $warning-color); // old.spectre.css
+@include bg-color-variant('.bg-warning', 'warning-color', $warning-color);
 
-// @include text-color-variant(".text-light", $light-color); // old spectre.css
-@include text-color-variant(".text-light", 'light-color');
-
-// @include text-color-variant(".text-dark", $body-font-color); // old spectre.css
-@include text-color-variant(".text-dark", 'body-font-color');
-
-// @include text-color-variant(".text-success", $success-color); // old spectre.css
-@include text-color-variant(".text-success", 'success-color');
-
-// @include text-color-variant(".text-warning", $warning-color); // old spectre.css
-@include text-color-variant(".text-warning", 'warning-color');
-
-// @include text-color-variant(".text-error", $error-color); // old spectre.css
-@include text-color-variant(".text-error", 'error-color');
-
-// Background colors
-// @include bg-color-variant(".bg-primary", $primary-color); // old spectre.css
-@include bg-color-variant(".bg-primary", 'primary-color');
-
-// @include bg-color-variant(".bg-secondary", $secondary-color); // old.spectre.css
-@include bg-color-variant(".bg-secondary", 'secondary-color');
-
-// @include bg-color-variant(".bg-dark", $dark-color); // old.spectre.css
-@include bg-color-variant(".bg-dark", 'dark-color');
-
-// @include bg-color-variant(".bg-gray", $bg-color); // old.spectre.css
-@include bg-color-variant(".bg-gray", 'bg-color');
-
-// @include bg-color-variant(".bg-success", $success-color); // old.spectre.css
-@include bg-color-variant(".bg-success", 'success-color');
-
-// @include bg-color-variant(".bg-warning", $warning-color); // old.spectre.css
-@include bg-color-variant(".bg-warning", 'warning-color');
-
-// @include bg-color-variant(".bg-error", $error-color); // old.spectre.css
-@include bg-color-variant(".bg-error", 'error-color');
+/*
+  Gray colors.
+*/
+// @include bg-color-variant('.bg-gray', $bg-color); // old.spectre.css
+@include bg-color-variant('.bg-gray', 'bg-gray', $bg-gray); // ? .bg-gray is not $bg-color but directly $bg-gray.
+@include bg-color-variant('.bg-gray-dark', 'gray-color-dark', $gray-color-dark); // ! New color.
+@include bg-color-variant('.bg-gray-light', 'gray-color-light', $gray-color-light); // ! New color.

--- a/src/utilities/_colors.scss
+++ b/src/utilities/_colors.scss
@@ -29,7 +29,9 @@
 @include bg-color-variant('.bg-accent', 'accent-color', $accent-color); // ! New color.
 // @include bg-color-variant('.bg-dark', $dark-color); // old.spectre.css
 @include bg-color-variant('.bg-dark', 'dark-color', $dark-color);
+@include bg-color-variant('.bg-color-dark', 'bg-color-dark', $bg-color-dark); // ! New color that uses $bg-color-dark
 @include bg-color-variant('.bg-light', 'light-color', $light-color);
+@include bg-color-variant('.bg-color-light', 'bg-color-light', $bg-color-light); // ! New color that uses $bg-color-light
 // @include bg-color-variant('.bg-primary', $primary-color); // old spectre.css
 @include bg-color-variant('.bg-primary', 'primary-color', $primary-color);
 // @include bg-color-variant('.bg-secondary', $secondary-color); // old.spectre.css

--- a/src/utilities/_display.scss
+++ b/src/utilities/_display.scss
@@ -34,7 +34,7 @@
 }
 .text-assistive {
   border: 0;
-  clip: rect(0,0,0,0);
+  clip: rect(0, 0, 0, 0);
   height: 1px;
   margin: -1px;
   overflow: hidden;

--- a/src/utilities/_divider.scss
+++ b/src/utilities/_divider.scss
@@ -1,4 +1,4 @@
-@use '../function/css-variable-color' as *;
+@use '../functions' as *;
 @use '../variables' as *;
 
 // Divider
@@ -39,7 +39,7 @@
     // border-left: $border-width solid $border-color; // old spectre.css
     border-left: $border-width solid color('border-color');
     bottom: $unit-2;
-    content: "";
+    content: '';
     display: block;
     left: 50%;
     position: absolute;

--- a/src/utilities/_loading.scss
+++ b/src/utilities/_loading.scss
@@ -1,4 +1,4 @@
-@use '../function/css-variable-color' as *;
+@use '../functions' as *;
 @use '../variables' as *;
 
 // Loading
@@ -15,7 +15,7 @@
     border-radius: 50%;
     border-right-color: transparent;
     border-top-color: transparent;
-    content: "";
+    content: '';
     display: block;
     height: $unit-4;
     left: 50%;

--- a/src/utilities/_text.scss
+++ b/src/utilities/_text.scss
@@ -50,15 +50,15 @@
 }
 
 .text-small {
-  font-size: .9em;
+  font-size: 0.9em;
 }
 
 .text-tiny {
-  font-size: .8em;
+  font-size: 0.8em;
 }
 
 .text-muted {
-  opacity: .8;
+  opacity: 0.8;
 }
 
 // Text overflow utilities

--- a/variables.scss
+++ b/variables.scss
@@ -1,0 +1,1 @@
+@forward 'src/variables';


### PR DESCRIPTION
# v1.0.0-alpha.1

- Change file name from general `function/_css-variable-color.scss` to just `functions/_color.scss`. a8b14ac
- Move mixins from `mixins/_css-variable-color.scss` to separate files `_define-color.scss` and `_define-color-based-on.scss`. e9bb18b
- Change folder name from `function` to `functions` for Spectre.css naming consistency. 4582370
- Change `.bg-gray` to use `$bg-gray` SCSS variable instead of `$bg-color`. ebd492c
- Fix includes mixin `bg-color-variant()` by adding missing sass variables. ebd492c
- New background class colors `.bg-color-dark` and `.bg-color-light`. fb1224c
- Fix variable name from `$lighten` to `$lightness` in `textarea.form-input`. 54790ae
- Update missing `color()` function in styles and use prettier on files. aed7fe0
- Update sass variable name to css style and add `!important` to `text-color-variant` mixin. 03713ee

